### PR TITLE
Dynamic handling of template and avoid message replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,11 +1,17 @@
 {
   "name": "node-red-contrib-transform",
-  "version": "1.0.20",
+  "version": "1.1.0",
   "description": "JSONata message transformation.",
-  "author": "temior",
+  "contributors": [
+    "temior",
+    "Gilbert Gonzalez <gb@autanalabs.com>"
+  ],
   "license": "ISC",
   "keywords": [
-    "node-red"
+    "node-red",
+    "autana",
+    "transform",
+    "JSONata"
   ],
   "node-red": {
     "nodes": {

--- a/transform.html
+++ b/transform.html
@@ -13,6 +13,14 @@
             templateType: {
                 value: 'jsonata'
             },
+            target: {
+                value: 'payload',
+                required: true
+            },
+            targetType: {
+                value: 'msg',
+                required: true
+            },
             outputs: {
                 value: 1,
                 required: true
@@ -29,6 +37,11 @@
                 types: ['jsonata', 'msg', 'flow', 'global', 'env'],
                 typeField: "#node-input-templateType"
             });
+            $('#node-input-target').typedInput({
+                type: 'msg',
+                types: ['msg', 'flow', 'global'],
+                typeField: "#node-input-targetType"
+            });
             $("#node-input-outputs").spinner({ min: 1 });
         }
     });
@@ -43,6 +56,11 @@
         <label for="node-input-template"> Template</label>
         <input type="text" id="node-input-template">
         <input type="hidden" id="node-input-templateType">
+    </div>
+    <div class="form-row">
+        <label for="node-input-target"> Target</label>
+        <input type="text" id="node-input-target">
+        <input type="hidden" id="node-input-targetType">
     </div>
     <div class="form-row" style="position: absolute; bottom: -4px;" >
         <label for="node-input-outputs"><i class="fa fa-arrow-circle-right"></i> Outputs</label>

--- a/transform.html
+++ b/transform.html
@@ -8,7 +8,10 @@
             },
             template: {
                 value: '{	   "topic": topic,	   "payload": payload	}',
-                required: true
+                required: false
+            },
+            templateType: {
+                value: 'jsonata'
             },
             outputs: {
                 value: 1,
@@ -21,7 +24,11 @@
             return this.name || 'transform';
         },
         oneditprepare: function () {
-            $('#node-input-template').typedInput({ type: 'jsonata', types: ['jsonata'] });
+            $('#node-input-template').typedInput({
+                type: 'jsonata',
+                types: ['jsonata', 'msg', 'flow', 'global', 'env'],
+                typeField: "#node-input-templateType"
+            });
             $("#node-input-outputs").spinner({ min: 1 });
         }
     });
@@ -35,6 +42,7 @@
     <div class="form-row">
         <label for="node-input-template"> Template</label>
         <input type="text" id="node-input-template">
+        <input type="hidden" id="node-input-templateType">
     </div>
     <div class="form-row" style="position: absolute; bottom: -4px;" >
         <label for="node-input-outputs"><i class="fa fa-arrow-circle-right"></i> Outputs</label>

--- a/transform.js
+++ b/transform.js
@@ -26,15 +26,25 @@ module.exports = function (RED) {
         return result;
     }
 
+    function getConfiguredTemplateValue(node, msg, exp, expType) {
+        if (expType == 'jsonata') {
+            return exp;
+        } else {
+            return RED.util.evaluateNodeProperty(exp, expType, node, msg);
+        }
+    }
+
     function TransformNode(config) {
         RED.nodes.createNode(this, config);
 
         const nodeExpression = config.template;
+        const nodeExpressionType = config.templateType;
         const node = this;
 
         this.on('input', (message, send, done) => {
             let error, result;
-            const expression = message.template || nodeExpression;
+            const expression = message.template
+                || getConfiguredTemplateValue(node, message, nodeExpression, nodeExpressionType);
 
             if (!expression) {
                 error = {

--- a/transform.js
+++ b/transform.js
@@ -16,12 +16,14 @@ module.exports = function (RED) {
     }
 
     function transform(message, expression) {
-       
+
         const result = RED.util.evaluateJSONataExpression(expression, message);
 
+        /*
         if (!isFlowPacket(result)) {
             throw new Error('The transformation result has an invalid structure.');
         }
+        */
 
         return result;
     }
@@ -39,6 +41,8 @@ module.exports = function (RED) {
 
         const nodeExpression = config.template;
         const nodeExpressionType = config.templateType;
+        const nodeTarget = config.target;
+        const nodeTargetType = config.targetType;
         const node = this;
 
         this.on('input', (message, send, done) => {
@@ -63,7 +67,19 @@ module.exports = function (RED) {
             if (error) {
                 done(error);
             } else {
-                send(result);
+                if (nodeTargetType == 'msg') {
+                    RED.util.setMessageProperty(message, nodeTarget, result, true);
+
+                } else if (nodeTargetType == 'flow') {
+                    var flowContext = this.context().flow;
+                    flowContext.set(nodeTarget, result);
+
+                } else if (nodeTargetType == 'global') {
+                    var globalContext = this.context().global;
+                    globalContext.set(nodeTarget, result);
+                }
+
+                send(message);
                 done();
             }
         });

--- a/transform.js
+++ b/transform.js
@@ -16,6 +16,7 @@ module.exports = function (RED) {
     }
 
     function transform(message, expression) {
+       
         const result = RED.util.evaluateJSONataExpression(expression, message);
 
         if (!isFlowPacket(result)) {
@@ -28,13 +29,23 @@ module.exports = function (RED) {
     function TransformNode(config) {
         RED.nodes.createNode(this, config);
 
-        const expression = build(config.template, this);
+        const nodeExpression = config.template;
+        const node = this;
 
         this.on('input', (message, send, done) => {
             let error, result;
+            const expression = message.template || nodeExpression;
+
+            if (!expression) {
+                error = {
+                    message: 'No template specified'
+                }
+                done(error);
+            }
 
             try {
-                result = transform(message, expression);
+                const preparedExpression = build(expression, node);
+                result = transform(message, preparedExpression);
             } catch (e) {
                 error = e.message;
             }


### PR DESCRIPTION
- Enable receive template from msg, flow, global and env too. 
- Added "Target" field to send the transformation result to a property of msg, flow or global context, avoiding replacement of the message object
- The template is prepared on node.input event.